### PR TITLE
Fix: children과 onClick 타입 설정 및 적용

### DIFF
--- a/components/reusable/Buttons/CheckedBtn.tsx
+++ b/components/reusable/Buttons/CheckedBtn.tsx
@@ -2,10 +2,10 @@ import { styled } from 'styled-components';
 import theme from '../../../styles/theme';
 import { ButtonProps } from './SquareBtn';
 
-const CheckedBtn = ({ onClick, disabled = false }: ButtonProps) => {
+const CheckedBtn = ({ onClick, disabled = false, children }: ButtonProps) => {
   return (
     <ButtonWrapper onClick={onClick} disabled={disabled}>
-      중복확인
+      {children}
     </ButtonWrapper>
   );
 };

--- a/components/reusable/Buttons/CheckedBtn.tsx
+++ b/components/reusable/Buttons/CheckedBtn.tsx
@@ -2,9 +2,9 @@ import { styled } from 'styled-components';
 import theme from '../../../styles/theme';
 import { ButtonProps } from './SquareBtn';
 
-const CheckedBtn = ({ onClick, disabled = false, children }: ButtonProps) => {
+const CheckedBtn = ({ onClick, disabled = false, children, ...props }: ButtonProps) => {
   return (
-    <ButtonWrapper onClick={onClick} disabled={disabled}>
+    <ButtonWrapper onClick={onClick} disabled={disabled} {...props}>
       {children}
     </ButtonWrapper>
   );

--- a/components/reusable/Buttons/QuestionBtn.tsx
+++ b/components/reusable/Buttons/QuestionBtn.tsx
@@ -3,9 +3,9 @@ import theme from '../../../styles/theme';
 import { ButtonProps } from './SquareBtn';
 import PencilIcon from '../../../assets/icons/Pencil.svg';
 
-const QuestionBtn = ({ onClick, children }: ButtonProps) => {
+const QuestionBtn = ({ onClick, children, ...props }: ButtonProps) => {
   return (
-    <ButtonWrapper onClick={onClick}>
+    <ButtonWrapper onClick={onClick} {...props}>
       <IconWrapper>
         <PencilIcon alt="연필" width="24" height="24" />
       </IconWrapper>

--- a/components/reusable/Buttons/QuestionBtn.tsx
+++ b/components/reusable/Buttons/QuestionBtn.tsx
@@ -3,13 +3,13 @@ import theme from '../../../styles/theme';
 import { ButtonProps } from './SquareBtn';
 import PencilIcon from '../../../assets/icons/Pencil.svg';
 
-const QuestionBtn = ({ onClick }: ButtonProps) => {
+const QuestionBtn = ({ onClick, children }: ButtonProps) => {
   return (
     <ButtonWrapper onClick={onClick}>
       <IconWrapper>
         <PencilIcon alt="연필" width="24" height="24" />
       </IconWrapper>
-      질문하기
+      {children}
     </ButtonWrapper>
   );
 };

--- a/components/reusable/Buttons/SignoutBtn.tsx
+++ b/components/reusable/Buttons/SignoutBtn.tsx
@@ -2,8 +2,12 @@ import { styled } from 'styled-components';
 import theme from '../../../styles/theme';
 import { ButtonProps } from './SquareBtn';
 
-const SignoutBtn = ({ onClick, children }: ButtonProps) => {
-  return <ButtonWrapper onClick={onClick}>{children}</ButtonWrapper>;
+const SignoutBtn = ({ onClick, children, ...props }: ButtonProps) => {
+  return (
+    <ButtonWrapper onClick={onClick} {...props}>
+      {children}
+    </ButtonWrapper>
+  );
 };
 
 export default SignoutBtn;

--- a/components/reusable/Buttons/SignoutBtn.tsx
+++ b/components/reusable/Buttons/SignoutBtn.tsx
@@ -2,8 +2,8 @@ import { styled } from 'styled-components';
 import theme from '../../../styles/theme';
 import { ButtonProps } from './SquareBtn';
 
-const SignoutBtn = ({ onClick }: ButtonProps) => {
-  return <ButtonWrapper onClick={onClick}>탈퇴하기</ButtonWrapper>;
+const SignoutBtn = ({ onClick, children }: ButtonProps) => {
+  return <ButtonWrapper onClick={onClick}>{children}</ButtonWrapper>;
 };
 
 export default SignoutBtn;

--- a/components/reusable/Buttons/SquareBtn.tsx
+++ b/components/reusable/Buttons/SquareBtn.tsx
@@ -1,16 +1,16 @@
-import { ReactNode } from 'react';
+import { ButtonHTMLAttributes, ReactNode } from 'react';
 import { styled } from 'styled-components';
 import theme from '../../../styles/theme';
 
-export interface ButtonProps {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   onClick?: (event: React.MouseEvent<HTMLElement>) => {};
   disabled?: boolean;
   children: ReactNode;
 }
 
-const UploadBtn = ({ onClick, disabled = false, children }: ButtonProps) => {
+const UploadBtn = ({ onClick, disabled = false, children, ...props }: ButtonProps) => {
   return (
-    <ButtonWrapper onClick={onClick} disabled={disabled}>
+    <ButtonWrapper onClick={onClick} disabled={disabled} {...props}>
       {children}
     </ButtonWrapper>
   );

--- a/components/reusable/Buttons/SquareBtn.tsx
+++ b/components/reusable/Buttons/SquareBtn.tsx
@@ -1,10 +1,11 @@
+import { ReactNode } from 'react';
 import { styled } from 'styled-components';
 import theme from '../../../styles/theme';
 
 export interface ButtonProps {
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => {};
   disabled?: boolean;
-  children: string;
+  children: ReactNode;
 }
 
 const UploadBtn = ({ onClick, disabled = false, children }: ButtonProps) => {


### PR DESCRIPTION
## Summary
children과 onClick 타입 설정 및 적용

## Description
- 이슈 넘버: #26 
- 관련 문서: https://simsimjae.tistory.com/426

## Details
- ButtonProps 의 children 타입을 string -> ReactNode
- onClick 함수 React.MouseEvent<HTMLElement> 이벤트 타입 설정
- 다른 버튼들도 같이 적용