### PR TITLE
[#6] fix: onClick 타입 수정 및 예약어와 변수 중복 해결

### DIFF
--- a/components/reusable/Buttons/CheckedBtn.tsx
+++ b/components/reusable/Buttons/CheckedBtn.tsx
@@ -2,9 +2,9 @@ import { styled } from 'styled-components';
 import theme from '../../../styles/theme';
 import { ButtonProps } from './SquareBtn';
 
-const CheckedBtn = ({ onClick, disabled = false, children, ...props }: ButtonProps) => {
+const CheckedBtn = ({ onClick, able = true, children, ...props }: ButtonProps) => {
   return (
-    <ButtonWrapper onClick={onClick} disabled={disabled} {...props}>
+    <ButtonWrapper onClick={onClick} able={able} {...props}>
       {children}
     </ButtonWrapper>
   );

--- a/components/reusable/Buttons/SquareBtn.tsx
+++ b/components/reusable/Buttons/SquareBtn.tsx
@@ -3,20 +3,20 @@ import { styled } from 'styled-components';
 import theme from '../../../styles/theme';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  onClick?: (event: React.MouseEvent<HTMLElement>) => {};
-  disabled?: boolean;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  able?: boolean;
   children: ReactNode;
 }
 
-const UploadBtn = ({ onClick, disabled = false, children, ...props }: ButtonProps) => {
+const SquareBtn = ({ onClick, able = true, children, ...props }: ButtonProps) => {
   return (
-    <ButtonWrapper onClick={onClick} disabled={disabled} {...props}>
+    <ButtonWrapper onClick={onClick} able={able} {...props}>
       {children}
     </ButtonWrapper>
   );
 };
 
-export default UploadBtn;
+export default SquareBtn;
 
 const ButtonWrapper = styled.button<ButtonProps>`
   height: 56px;


### PR DESCRIPTION
## Summary
- onClick 타입 오류 해결
- 예약어 & 변수 중복되는 문제 해결

## Description
- 이슈 넘버: #6 


## Details
- onClick 타입 오류 해결
   - `() => {}` -> `() => void`로 수정
- 예약어 & 변수 중복되는 문제 해결
   - disabled가 button disabled 예약어랑 충돌되는 문제 발생
   - 변수명 `disabled` -> `able`로 수정

