### PR TITLE
[#2] refactor: Tag 컴포넌트 리팩토링

### DIFF
--- a/components/reusable/Card/index.tsx
+++ b/components/reusable/Card/index.tsx
@@ -55,7 +55,9 @@ const Card = () => {
 
   return (
     <StyledCard>
-      <Tag variant="color" content="직무" />
+      <Tag color="color" size="small">
+        <p>직무</p>
+      </Tag>
       <Spacing direction="vertical" size={16} />
       <Title>제목입니다제목입니다제목입니다제목입니다제목입니다제목입니다</Title>
       <Spacing direction="vertical" size={16} />
@@ -67,17 +69,29 @@ const Card = () => {
       <Spacing direction="vertical" size={16} />
       <StackTagsArea>
         <StackTagsWrap ref={ref}>
-          <Tag variant="gray" content="스택2222" />
+          <Tag color="gray" size="big">
+            <p>스택2222</p>
+          </Tag>
           <Spacing direction="horizontal" size={8} />
-          <Tag variant="gray" content="스택" />
+          <Tag color="gray" size="big">
+            <p>스택2222</p>
+          </Tag>
           <Spacing direction="horizontal" size={8} />
-          <Tag variant="gray" content="스택" />
+          <Tag color="gray" size="big">
+            <p>스택2222</p>
+          </Tag>
           <Spacing direction="horizontal" size={8} />
-          <Tag variant="gray" content="스택" />
+          <Tag color="gray" size="big">
+            <p>스택2222</p>
+          </Tag>
           <Spacing direction="horizontal" size={8} />
-          <Tag variant="gray" content="스택" />
+          <Tag color="gray" size="big">
+            <p>스택2222</p>
+          </Tag>
           <Spacing direction="horizontal" size={8} />
-          <Tag variant="gray" content="스택" />
+          <Tag color="gray" size="big">
+            <p>스택2222</p>
+          </Tag>
         </StackTagsWrap>
         {useIsOverflow({ ref }) && scrollState === 'right' && (
           <OverflowBoxRight>

--- a/components/reusable/Tag.tsx
+++ b/components/reusable/Tag.tsx
@@ -1,15 +1,17 @@
 import theme from '@/styles/theme';
+import { ReactElement } from 'react';
 import styled from 'styled-components';
 
 interface Props extends React.HTMLAttributes<HTMLSpanElement> {
-  readonly variant: 'color' | 'gray';
-  readonly content: string;
+  color: 'color' | 'gray';
+  size: 'small' | 'big';
+  children: ReactElement;
 }
 
-const Tag = ({ variant = 'color', content, ...props }: Props) => {
+const Tag = ({ color = 'color', size = 'small', children, ...props }: Props) => {
   return (
-    <StyledTag variant={variant} {...props}>
-      {content}
+    <StyledTag color={color} size={size} {...props}>
+      {children}
     </StyledTag>
   );
 };
@@ -17,13 +19,14 @@ const Tag = ({ variant = 'color', content, ...props }: Props) => {
 export default Tag;
 
 interface StyledTagProps {
-  readonly variant: 'color' | 'gray';
+  color: 'color' | 'gray';
+  size: 'small' | 'big';
 }
 
 const StyledTag = styled.span<StyledTagProps>`
-  background-color: ${(props) => backgroundColor[props.variant]};
-  color: ${(props) => textColor[props.variant]};
-  border-radius: ${(props) => radiusSize[props.variant]};
+  background-color: ${(props) => backgroundColor[props.color]};
+  color: ${(props) => textColor[props.color]};
+  border-radius: ${(props) => radiusSize[props.size]};
   height: 24px;
   min-width: fit-content;
   font-size: ${theme.fontStyles.Caption.fontSize}px;
@@ -43,6 +46,6 @@ const textColor = {
 };
 
 const radiusSize = {
-  color: '8px',
-  gray: '100px',
+  small: '8px',
+  big: '100px',
 };


### PR DESCRIPTION
## Summary
Tag 컴포넌트의 재사용성 증대를 위해서 리팩토링 하였습니다

## Description
- 이슈 넘버: #2 

## Details
- variant로 정해지는 두 가지 옵션(color / border-radius)을 각각 선택될 수 있도록하였습니다.
   - color / size로 분류 
- content로 전달되던 내용을 컴포넌트를 불러오는 곳에서의 가독성을 위해서 children으로 변경하였습니다.
   - 자식은 글자 하나만 가지므로 `ReactElement` 사용함

