### PR TITLE
[#24] Layout 추가

### DIFF
--- a/pages/Layout.tsx
+++ b/pages/Layout.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from 'react';
+import Footer from '../components/reusable/Footer';
+
+const Layout = ({ children }: { children: ReactElement }) => {
+  return (
+    <>
+      {children}
+      <Footer />
+    </>
+  );
+};
+
+export default Layout;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,17 +1,28 @@
 import { AppProps } from 'next/app';
 import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { NextPage } from 'next';
+import { ReactElement, ReactNode } from 'react';
 import { GlobalStyle } from '../styles/globalStyle';
 import Footer from '../components/reusable/Footer';
 
-const MyApp = ({ Component, pageProps }: AppProps) => {
+export type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
+  const getLayout = Component.getLayout ?? ((page) => page);
   const queryClient = new QueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>
       <RecoilRoot>
         <GlobalStyle />
-        <Component {...pageProps} />
+        {getLayout(<Component {...pageProps} />)}
         <Footer />
       </RecoilRoot>
     </QueryClientProvider>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,7 @@
-import type { NextPage } from 'next';
+import type { NextPageWithLayout } from './_app';
 
-const Home: NextPage = () => {
-  return (
-    <>
-      <h1>Home Page</h1>
-    </>
-  );
+const Home: NextPageWithLayout = () => {
+  return <h1>Home Page</h1>;
 };
 
 export default Home;


### PR DESCRIPTION
## Summary
어떤 기능을 처리했는지 작성해주세요

## Description
- 이슈 넘버: #24 
- 관련 문서: https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts#layout-pattern (공식 문서)

## Details
- `getLayout`을 활용하여서 routing된 페이지 위아래에 푸터와 헤더가 들어갈 수 있게하였습니다.

## Reference
https://velog.io/@sssssssssy/getLayout
https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts#layout-pattern
